### PR TITLE
Update license value for Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
     "php": "^5.6|^7"
   },
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "require": {},
   "scripts": {
     "phpcs": "phpcs"


### PR DESCRIPTION
The SPDX value changed recently.
https://spdx.org/licenses/GPL-2.0-or-later.html

The license value should also be changed for `@license` tags as well.