### PR TITLE
Improved font weight descriptions

### DIFF
--- a/lib/plugins/woocommerce/scss/account-page/index.scss
+++ b/lib/plugins/woocommerce/scss/account-page/index.scss
@@ -17,7 +17,7 @@
 
 			.is-active > a {
 				color: $dark-grey;
-				font-weight: $font-weight--bolder;
+				font-weight: $font-weight--bold;
 			}
 		}
 

--- a/lib/plugins/woocommerce/scss/forms/index.scss
+++ b/lib/plugins/woocommerce/scss/forms/index.scss
@@ -19,7 +19,7 @@
 		color: $white;
 		background-color: $dark-grey;
 		font-size: $forms-button--font-size;
-		font-weight: $font-weight--bold;
+		font-weight: $font-weight--semibold;
 		text-align: center;
 		white-space: normal;
 		text-decoration: none;

--- a/lib/plugins/woocommerce/scss/shop-page/index.scss
+++ b/lib/plugins/woocommerce/scss/shop-page/index.scss
@@ -95,7 +95,7 @@
 						color: $dark-grey;
 						background-color: $lightest-grey;
 						font-size: $shop-page-navigation-link--font-size;
-						font-weight: $font-weight--bold;
+						font-weight: $font-weight--semibold;
 						line-height: $line-height--normal;
 						text-decoration: none;
 						cursor: pointer;

--- a/scss/common-classes/index.scss
+++ b/scss/common-classes/index.scss
@@ -62,7 +62,7 @@
 	.entry-title {
 		margin-bottom: 10px;
 		font-size: $archive-author-box__entry-title--font-size;
-		font-weight: $font-weight--bold;
+		font-weight: $font-weight--semibold;
 	}
 }
 
@@ -114,7 +114,7 @@
 .author-box-title {
 	margin-bottom: 10px;
 	font-size: $archive-author-box__entry-title--font-size;
-	font-weight: $font-weight--bold;
+	font-weight: $font-weight--semibold;
 }
 
 .entry-title {
@@ -140,7 +140,7 @@
 .widget-title {
 	margin-bottom: 20px;
 	font-size: $widget-title--font-size;
-	font-weight: $font-weight--bold;
+	font-weight: $font-weight--semibold;
 }
 
 /* WordPress
@@ -202,7 +202,7 @@ img.alignright,
 .wp-caption-text {
 	margin: 0;
 	font-size: $entry-content__caption--font-size;
-	font-weight: $font-weight--bold;
+	font-weight: $font-weight--semibold;
 	text-align: center;
 }
 

--- a/scss/content-area/index.scss
+++ b/scss/content-area/index.scss
@@ -40,7 +40,7 @@
 	.caption {
 		margin-top: -20px;
 		font-size: $entry-content__caption--font-size;
-		font-weight: $font-weight--bold;
+		font-weight: $font-weight--semibold;
 		text-align: center;
 	}
 }
@@ -105,7 +105,7 @@
 		color: $archive-pagination--font-color;
 		background-color: $archive-pagination--background-color;
 		font-size: $archive-pagination--font-size;
-		font-weight: $font-weight--bold;
+		font-weight: $font-weight--semibold;
 		text-decoration: none;
 		cursor: pointer;
 	}

--- a/scss/defaults/index.scss
+++ b/scss/defaults/index.scss
@@ -21,7 +21,7 @@ body {
 	background-color: $body--background-color;
 	font-family: $body--font-family;
 	font-size: $body--font-size;
-	font-weight: $font-weight--normal;
+	font-weight: $font-weight--regular;
 	line-height: $line-height--normal;
 }
 
@@ -73,7 +73,7 @@ hr {
 
 b,
 strong {
-	font-weight: $font-weight--bolder;
+	font-weight: $font-weight--bold;
 }
 
 blockquote,
@@ -113,7 +113,7 @@ h5,
 h6 {
 	margin: 0 0 20px;
 	font-family: $headings--font-family;
-	font-weight: $font-weight--normal;
+	font-weight: $font-weight--regular;
 	line-height: $line-height--small;
 }
 
@@ -127,7 +127,7 @@ h2 {
 
 .entry-content h3,
 .entry-content h4 {
-	font-weight: $font-weight--bold;
+	font-weight: $font-weight--semibold;
 }
 
 h3 {
@@ -255,7 +255,7 @@ textarea {
 	color: $forms--font-color;
 	background-color: $forms__background-color;
 	font-size: $forms--font-size;
-	font-weight: $font-weight--normal;
+	font-weight: $font-weight--regular;
 }
 
 input:focus,
@@ -286,7 +286,7 @@ button {
 	color: $button--font-color;
 	background-color: $button--background-color;
 	font-size: $button--font-size;
-	font-weight: $font-weight--bold;
+	font-weight: $font-weight--semibold;
 	white-space: normal;
 	text-decoration: none;
 	cursor: pointer;
@@ -309,7 +309,7 @@ input[type="button"] {
 	color: $button--font-color;
 	background-color: $button--background-color;
 	font-size: $button--font-size;
-	font-weight: $font-weight--bold;
+	font-weight: $font-weight--semibold;
 	white-space: normal;
 	text-decoration: none;
 	cursor: pointer;
@@ -332,7 +332,7 @@ input[type="reset"] {
 	color: $button--font-color;
 	background-color: $button--background-color;
 	font-size: $button--font-size;
-	font-weight: $font-weight--bold;
+	font-weight: $font-weight--semibold;
 	white-space: normal;
 	text-decoration: none;
 	cursor: pointer;
@@ -355,7 +355,7 @@ input[type="submit"] {
 	color: $button--font-color;
 	background-color: $button--background-color;
 	font-size: $button--font-size;
-	font-weight: $font-weight--bold;
+	font-weight: $font-weight--semibold;
 	white-space: normal;
 	text-decoration: none;
 	cursor: pointer;
@@ -379,7 +379,7 @@ input[type="submit"] {
 	color: $button--font-color;
 	background-color: $button--background-color;
 	font-size: $button--font-size;
-	font-weight: $font-weight--bold;
+	font-weight: $font-weight--semibold;
 	white-space: normal;
 	text-decoration: none;
 	cursor: pointer;
@@ -433,7 +433,7 @@ td {
 
 th {
 	padding: 0 6px;
-	font-weight: $font-weight--normal;
+	font-weight: $font-weight--regular;
 	text-align: left;
 
 	&:first-child {
@@ -472,7 +472,7 @@ th {
 	background: $body--background-color;
 	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
 	font-size: 1em;
-	font-weight: $font-weight--bolder;
+	font-weight: $font-weight--bold;
 	text-decoration: none;
 }
 

--- a/scss/header/index.scss
+++ b/scss/header/index.scss
@@ -31,7 +31,7 @@
 .site-title {
 	margin-bottom: 0;
 	font-size: $site-title--font-size;
-	font-weight: $font-weight--bold;
+	font-weight: $font-weight--semibold;
 	line-height: $line-height--smaller;
 
 	a,

--- a/scss/menu/index.scss
+++ b/scss/menu/index.scss
@@ -39,7 +39,7 @@
 	> .menu-bold > a {
 
 		@media only screen and (min-width: $standard-screen-width) {
-			font-weight: $font-weight--bolder;
+			font-weight: $font-weight--bold;
 		}
 	}
 
@@ -52,7 +52,7 @@
 			border-radius: 3px;
 			color: $menu-highlight__link--font-color;
 			background-color: $menu-highlight__link--background-color;
-			font-weight: $font-weight--bold;
+			font-weight: $font-weight--semibold;
 		}
 	}
 
@@ -71,7 +71,7 @@
 		outline-offset: -1px;
 		color: $genesis-nav-menu--font-color;
 		font-size: $genesis-nav-menu--font-size;
-		font-weight: $font-weight--normal;
+		font-weight: $font-weight--regular;
 		text-decoration: none;
 	}
 

--- a/scss/utilities/index.scss
+++ b/scss/utilities/index.scss
@@ -56,9 +56,9 @@ $body--font-family: $base-font;
 $headings--font-family: $base-font;
 
 // Font weights
-$font-weight--normal: 400;
-$font-weight--bold: 600;
-$font-weight--bolder: 700;
+$font-weight--regular: 400;
+$font-weight--semibold: 600;
+$font-weight--bold: 700;
 
 // Line heights
 $line-height--big: 20px;


### PR DESCRIPTION
Changed the SCSS variable names for the font weights. They were given as *normal, *bold and *bolder for weights 400, 600 and 700 respectively; however the font names for those weights  in the Source Sans typeface are *regular, *semibold and *bold respectively, which follows the usual convention for typeface naming. This should help to avoid confusion, especially the 'bold' weight (or, rather, semibold...).