### PR TITLE
Updated to WPCS 1.1 and excluded multi-line function call changes.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.3",
-    "wp-coding-standards/wpcs": "^1.0",
+    "wp-coding-standards/wpcs": "^1.1",
     "wimg/php-compatibility": "^8.2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
   },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,6 +36,9 @@
 	<!-- Use the WordPress ruleset, with exclusions. -->
 	<rule ref="WordPress">
 			<exclude name="Squiz.PHP.CommentedOutCode.Found"/>
+			<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
+			<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments"/>
+			<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
 	</rule>
 
 	<!-- Page templates currently use underscores for historic reasons. -->


### PR DESCRIPTION
While I am 100% for following coding standards, the change to multi-line function calls in WPCS 1.1 just doesn't look right to me (yet).

For now, 
```[php]
add_action( 'customize_register', function( $wp_customize ) {
...code...
});
```

makes more sense to me than

```[php]
add_action( 
    'customize_register',
    function( $wp_customize ) {
        ...code...
    }
);
```

